### PR TITLE
Echo comments and commands to make output clearer

### DIFF
--- a/gradle/pre-merge.sh
+++ b/gradle/pre-merge.sh
@@ -1,26 +1,50 @@
 #!/bin/bash -e
 BUILD_NAME=${GITHUB_RUN_ID:=local-$(date +%s)}
 
-# Get Launchable CLI installed. If you can, make it a part of the builder image to speed things up
+echo
+echo "===== BEGIN LAUNCHABLE ====="
+
+echo
+echo "# Install the Launchable CLI. If you can, install it as part of the builder image to speed things up"
+echo "# Command: pip3 install --user launchable~=1.0 > /dev/null"
+echo
 pip3 install --user launchable~=1.0 > /dev/null
+
 export PATH=~/.local/bin:$PATH
 
-set -x
-# Verify that Launchable setup is all correct. Useful primarily while you work on integration
+echo "# Verify that Launchable setup is all correct. Useful primarily while you work on integration"
+echo "# Command: launchable verify"
+echo
 launchable verify
 
-# Tell Launchable about the build you are producing and testing
+echo
+echo "# Tell Launchable about the build you are producing and testing"
+echo "# Command: launchable record build --name \"\$BUILD_NAME\" --source .."
+echo
 launchable record build --name "$BUILD_NAME" --source ..
 
-# Find 25% of the relevant tests to run for this change
+echo -e "\n# Find 25% of the relevant tests to run for this change"
+echo -e "# Command: launchable subset --target 25% --build \"\$BUILD_NAME\" gradle src/test/java > subset.txt\n"
 launchable subset --target 25% --build "$BUILD_NAME" gradle src/test/java > subset.txt
 
+echo "# Inspect the subset file"
+echo "# Command: cat subset.txt"
+cat subset.txt
+
 function record() {
-  # Record test results
-  launchable record test --build "$BUILD_NAME" gradle build/test-results/test
+  echo -e "\n# Record test results"
+  echo -e "# Command: launchable record tests --build \"\$BUILD_NAME\" gradle build/test-results/test\n"
+  launchable record tests --build "$BUILD_NAME" gradle build/test-results/test
+  
+  echo
+  echo "===== END LAUNCHABLE ====="
+  echo
 }
 
 trap record EXIT
 
-# Run gradle with the subset of tests
+echo
+echo "# Run gradle with the subset of tests"
+echo "# Command: ./gradlew test \$(< subset.txt)"
+echo
 ./gradlew test $(< subset.txt)

--- a/gradle/pre-merge.sh
+++ b/gradle/pre-merge.sh
@@ -34,8 +34,10 @@ echo "# Command: cat subset.txt"
 cat subset.txt
 
 function record() {
-  echo -e "\n# Record test results"
-  echo -e "# Command: launchable record tests --build \"\$BUILD_NAME\" gradle build/test-results/test\n"
+  echo
+  echo "# Record test results"
+  echo "# Command: launchable record tests --build \"\$BUILD_NAME\" gradle build/test-results/test"
+  echo
   launchable record tests --build "$BUILD_NAME" gradle build/test-results/test
   
   echo

--- a/gradle/pre-merge.sh
+++ b/gradle/pre-merge.sh
@@ -23,10 +23,12 @@ echo "# Command: launchable record build --name \"\$BUILD_NAME\" --source .."
 echo
 launchable record build --name "$BUILD_NAME" --source ..
 
-echo -e "\n# Find 25% of the relevant tests to run for this change"
-echo -e "# Command: launchable subset --target 25% --build \"\$BUILD_NAME\" gradle src/test/java > subset.txt\n"
+echo
+echo "# Find 25% of the relevant tests to run for this change"
+echo "# Command: launchable subset --target 25% --build \"\$BUILD_NAME\" gradle src/test/java > subset.txt"
 launchable subset --target 25% --build "$BUILD_NAME" gradle src/test/java > subset.txt
 
+echo
 echo "# Inspect the subset file"
 echo "# Command: cat subset.txt"
 cat subset.txt


### PR DESCRIPTION
Normally, we'd use `set -x` to output commands, but 1) that outputs the `echo ...` commands, too, and 2) I want to show the commands *before* variable and command substitution (e.g. $BUILD_NAME). I would like to show the real commands, too (using `set -x`), but the subsequent `set +x` command ends up being printed! You can run the command in a subprocess to get around this (`(set -x; ./gradlew ...)`), but doing so printed the commands out of order.