### PR TITLE
add timedOut test case

### DIFF
--- a/playwright/tests/timeout-example.spec.ts
+++ b/playwright/tests/timeout-example.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test("time-out", async ({ page }, testInfo) => {
+  test.setTimeout(1);
+  await page.goto("https://playwright.dev/");
+  await expect(page).toHaveTitle(new RegExp("Playwright"));
+});


### PR DESCRIPTION
Playwright test status are not only "passed", "failed", and "skipped" but also "timedOut" and "interrupted"

see: https://playwright.dev/docs/api/class-testresult#test-result-status

Thus, I added "timedOut" test case to produce report file